### PR TITLE
Fix milliseconds() to report the correct unit

### DIFF
--- a/fluentmetrics/__init__.py
+++ b/fluentmetrics/__init__.py
@@ -296,7 +296,7 @@ class FluentMetric(object):
         mn = kwargs.get('MetricName')
         count = kwargs.get('Value', 1)
         self.log(Value=count,
-                 Unit='Microseconds',
+                 Unit='Milliseconds',
                  MetricName=mn)
         return self
 


### PR DESCRIPTION
The `milliseconds()` function was uploading the value as microseconds. Correct the unit so the values are reported correctly to CloudWatch Metrics