### PR TITLE
Positional parameters & better timer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ In this example, we're logging two metrics called `StartupTime` and `StuffTime` 
 m = FluentMetric().with_namespace('Performance')
 m.log(MetricName='StartupTime', Value=27, Unit='Seconds')
 do_stuff()
-m.log(MetricName='StuffTime', Value=12000, Unit='Milliseconds')
+m.log('StuffTime', 12000, 'Milliseconds')
 ```
 #### Values
 Obviously we need to log a value with each metric. This needs to be a number since we convert this value to a `float` before sending to CloudWatch. 
@@ -64,7 +64,7 @@ In this example, we're logging metric at one-second resolution:
 ```sh
 m = FluentMetric().with_namespace('Application/MyApp')
                   .with_storage_resolution(1)
-m.log(MetricName='Transactions/Sec', Value=trans_count, Unit='Count/Sec')
+m.log('Transactions/Sec', trans_count, 'Count/Sec')
 ```sh
 #### Dimensions
 A dimension defines how you want to slice and dice the metric. These are simply name-value pairs and you can define up to 10 per metric. Click [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#usingDimensions) for more details on using dimensions.
@@ -79,9 +79,9 @@ m = FluentMetric().with_namespace('Performance/EC2') \
                   .with_dimension('os', 'linux'). \
                   .with_dimension('instance-id', 'i-123456')
 boot_time = start_instance()
-m.log(MetricName='BootTime', Value=boot_time, Unit='Milliseconds')
+m.log('BootTime', boot_time, 'Milliseconds')
 restart_time = restart_instance()
-m.log(MetricName='RestartTime', Value=restart_time, Unit='Milliseconds')
+m.log('RestartTime', Value=restart_time, Unit='Milliseconds')
 ```
 #### Units
 CloudWatch has built-in logic to provide meaning to the metric values. We're not just logging a value--we're looking a value of some unit. By defining the unit type, CloudWatch will know how to properly present, aggregate and compare that value with other values. For example, if you submit a value with unit `Milliseconds`, then it can properly aggregate it up to seconds, minutes or hours. This is a list of the most current valid list of units. A more up-to-date list should be available [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html) under the **Unit** section,.
@@ -99,32 +99,32 @@ If you don't want to type out the individual unit name, there are shortcut metho
 m = FluentMetric().with_namespace('Performance/EC2') \
                   .with_dimension('os', 'linux'). \
                   .with_dimension('instance-id', 'i-123456')
-m.seconds(MetricName='CompletionInSeconds', Value='1000')
-m.microseconds(MetricName='CompletionInMicroseconds', Value='1000')
-m.milliseconds(MetricName='CompletionInMilliseconds', Value='1000')
-m.bytes(MetricName='SizeInBytes', Value='1000')
-m.kb(MetricName='SizeInKb', Value='1000')
-m.mb(MetricName='SizeInMb', Value='1000')
-m.gb(MetricName='SizeInGb', Value='1000')
-m.tb(MetricName='SizeInTb', Value='1000')
-m.bits(MetricName='SizeInBits', Value='1000')
-m.kbits(MetricName='SizeInKilobits', Value='1000')
-m.mbits(MetricName='SizeInMegabits', Value='1000')
-m.gbits(MetricName='SizeInGigabits', Value='1000')
-m.tbits(MetricName='SizeInTerabits', Value='1000')
-m.pct(MetricName='Percent', Value='20')
-m.count(MetricName='ItemCount', Value='20')
-m.bsec(MetricName='BandwidthBytesPerSecond', Value='1000')
-m.kbsec(MetricName='BandwidthKilobytesPerSecond', Value='1000')
-m.mbsec(MetricName='BandwidthMegabytesPerSecond', Value='1000')
-m.gbsec(MetricName='BandwidthGigabytesPerSecond', Value='1000')
-m.tbsec(MetricName='BandwidthTerabytesPerSecond', Value='1000')
-m.bitsec(MetricName='BandwidthBitsPerSecond', Value='1000')
-m.kbitsec(MetricName='BandwidthKilobitsPerSecond', Value='1000')
-m.mbitsec(MetricName='BandwidthMegabitsPerSecond', Value='1000')
-m.gbitsec(MetricName='BandwidthGigabitsPerSecond', Value='1000')
-m.tbitsec(MetricName='BandwidthTerabitsPerSecond', Value='1000')
-m.countsec(MetricName='ItemCountsPerSecond', Value='1000')
+m.seconds('CompletionInSeconds', 1000)
+m.microseconds('CompletionInMicroseconds', 1000)
+m.milliseconds('CompletionInMilliseconds', 1000)
+m.bytes('SizeInBytes', 1000)
+m.kb('SizeInKb', 1000)
+m.mb('SizeInMb', 1000)
+m.gb('SizeInGb', 1000)
+m.tb('SizeInTb', 1000)
+m.bits('SizeInBits', 1000)
+m.kbits('SizeInKilobits', 1000)
+m.mbits('SizeInMegabits', 1000)
+m.gbits('SizeInGigabits', 1000)
+m.tbits('SizeInTerabits', 1000)
+m.pct('Percent', 20)
+m.count('ItemCount', 20)
+m.bsec('BandwidthBytesPerSecond', 1000)
+m.kbsec('BandwidthKilobytesPerSecond', 1000)
+m.mbsec('BandwidthMegabytesPerSecond', 1000)
+m.gbsec('BandwidthGigabytesPerSecond', 1000)
+m.tbsec('BandwidthTerabytesPerSecond', 1000)
+m.bitsec('BandwidthBitsPerSecond', 1000)
+m.kbitsec('BandwidthKilobitsPerSecond', 1000)
+m.mbitsec('BandwidthMegabitsPerSecond', 1000)
+m.gbitsec('BandwidthGigabitsPerSecond', 1000)
+m.tbitsec('BandwidthTerabitsPerSecond', 1000)
+m.countsec('ItemCountsPerSecond', 1000)
 ```
 #### Timers
 One of the most common uses of logging is measuring performance. FluentMetrics allows you to activate multiple built-in timers by name and log the elapsed time in a single line of code. **NOTE:** The elapsed time value is automatically stored as unit `Milliseconds`.
@@ -134,13 +134,39 @@ In this example, we're starting timers `workflow` and `job1` at the same time. T
 m = FluentMetric()
 m.with_timer('workflow').with_timer('job1')
 do_job1()
-m.elapsed(MetricName='Job1CompletionTime', TimerName='job1')
+m.elapsed('Job1CompletionTime', 'job1')
 m.with_timer('job2')
 do_job2()
-m.elapsed(MetricName='Job2CompletionTime', TimerName='job2')
+m.elapsed('Job2CompletionTime', 'job2')
 finish_workflow()
-m.elapsed(MetricName='WorkflowCompletionTime', TimerName='workflow')
+m.elapsed('WorkflowCompletionTime', 'workflow')
 ```
+
+Python's `with` blocks are an even more reliable way to time code blocks:
+
+```python
+m = FluentMetric()
+
+with m.timer('PotentiallySlow'):
+    run_forest_run()
+```
+
+This times how long it takes `run_forest_run()` to execute and records the result
+in milliseconds.
+
+Alternately, you can use Python's decorator syntax:
+
+```python
+def task():
+    m = FluentMetric()
+
+    @m.timer('PotentiallySlow')
+    def run_forest_run():
+       jog_across_america() 
+
+    # it's not timed until the method is called
+    run_forest_run()
+
 #### Metric Stream ID
 A key feature of `FluentMetrics` is the metric stream ID. This ID will be added as a dimension and logged with every metric. The benefit of this dimension is to provide a distinct stream of metrics for an end-to-end operation. When you create a new instance of `FluentMetric`, you can either pass in your own value or `FluentMetrics` will generate a GUID. In CloudWatch, you can then see all of the metrics for a particular stream ID in chronological order. A metric stream can be a job, or a server or any way that you want to unique group a contiguous stream of metrics.
 *Example*:
@@ -158,7 +184,7 @@ This is the minimal amount of work you need to log--create a `FluentMetric` with
 ```sh
 from fluentmetrics import FluentMetric
 m = FluentMetric().with_namespace('Stats')
-m.log(MetricName='ActiveServerCount', Value='100', Unit='Count')
+m.log('ActiveServerCount', '100', 'Count')
 ```
 #### #2: Logging Multiple Metrics to the Same Namespace
 If you are logging multiple metrics to the same namespace, this is a great use case for `FluentMetrics`. You only need to create one instance of `FluentMetric` and specify a different metric name when you call `log`. 
@@ -166,10 +192,10 @@ If you are logging multiple metrics to the same namespace, this is a great use c
 ```sh
 from fluentmetrics import FluentMetric   
 m = FluentMetric().with_namespace('Stats')
-m.log(MetricName='ActiveServerCount', Value='10', Unit='Count') \
- .log(MetricName='StoppedServerCount', Value='20', Unit='Count') \
- .log(MetricName='ActiveLinuxCount', Value='50', Unit='Count') \
- .log(MetricName='ActiveWindowsCount', Value='50', Unit='Count')
+m.log('ActiveServerCount', '10', 'Count') \
+ .log('StoppedServerCount', '20', 'Count') \
+ .log('ActiveLinuxCount', '50', 'Count') \
+ .log('ActiveWindowsCount', '50', 'Count')
 ````
 #### #3: Logging Counts
 In the previous example, we logged a metric and identified the unit `Count`. Instead of specifying the unit, you can specify the type of object

--- a/fluentmetrics/metric.py
+++ b/fluentmetrics/metric.py
@@ -31,7 +31,7 @@ class Timer(object):
 
 
 class FluentMetric(object):
-    def __init__(self, client=None, **kwargs):
+    def __init__(self, client=None, Profile=None):
         self.stream_id = str(uuid.uuid4())
         self.dimensions = []
         self.timers = {}
@@ -42,7 +42,7 @@ class FluentMetric(object):
         if client:
             self.client = client
         else:
-            profile = kwargs.get('Profile')
+            profile = Profile
             if profile:
                 session = boto3.session.Session(profile_name=profile)
                 self.client = session.client('cloudwatch')
@@ -113,248 +113,194 @@ class FluentMetric(object):
         self.dimensions = self.dimension_stack.pop()
         return self
 
-    def elapsed(self, **kwargs):
-        tn = kwargs.get('TimerName')
-        mn = kwargs.get('MetricName')
-        if tn not in self.timers.keys():
-            logger.warn('No timer named {}'.format(tn))
+    def elapsed(self, MetricName, TimerName=None):
+        TimerName = TimerName or MetricName
+        if TimerName not in self.timers.keys():
+            logger.warn('No timer named {}'.format(TimerName))
             return
         self.log(Value=self.timers[tn].elapsed_in_ms(),
                  Unit='Milliseconds',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def countsec(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def countsec(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Count/Second',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def tbitsec(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def tbitsec(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Terabits/Second',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def gbitsec(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def gbitsec(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Gigabits/Second',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def mbitsec(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def mbitsec(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Megabits/Second',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def kbitsec(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def kbitsec(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Kilobits/Second',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def bitsec(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def bitsec(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Bits/Second',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def tbsec(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def tbsec(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Terabytes/Second',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def gbsec(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def gbsec(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Gigabytes/Second',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def mbsec(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def mbsec(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Megabytes/Second',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def kbsec(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def kbsec(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Kilobytes/Second',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def bsec(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def bsec(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Bytes/Second',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def pct(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def pct(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Percent',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def tbits(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def tbits(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Terabits',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def gbits(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def gbits(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Gigabits',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def mbits(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def mbits(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Megabits',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def kbits(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def kbits(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Kilobits',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def bits(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def bits(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Bits',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def tb(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def tb(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Terabytes',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def gb(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def gb(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Gigabytes',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def mb(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def mb(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Megabytes',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def kb(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def kb(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Kilobytes',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def bytes(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def bytes(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Bytes',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def milliseconds(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def milliseconds(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Milliseconds',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def microseconds(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def microseconds(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Microseconds',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def seconds(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def seconds(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Seconds',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def count(self, **kwargs):
-        mn = kwargs.get('MetricName')
-        count = kwargs.get('Value', 1)
-        self.log(Value=count,
+    def count(self, MetricName, Value=1):
+        self.log(Value=Value,
                  Unit='Count',
-                 MetricName=mn)
+                 MetricName=MetricName)
         return self
 
-    def log(self, **kwargs):
-        ts = kwargs.get('TimeStamp', arrow.utcnow()
-                        .format('YYYY-MM-DD HH:mm:ss ZZ'))
-        value = float(kwargs.get('Value'))
-        unit = kwargs.get('Unit')
+    def log(self, MetricName, Value, Unit, TimeStamp=None):
+        ts = TimeStamp or arrow.utcnow()
+        ts = ts.format('YYYY-MM-DD HH:mm:ss ZZ')
+        value = float(Value)
         md = []
         for dimension in self.dimensions:
             md.append({
-                        'MetricName': kwargs.get('MetricName'),
+                        'MetricName': MetricName,
                         'Dimensions': [dimension],
                         'Timestamp': ts,
                         'Value': value,
-                        'Unit': unit,
+                        'Unit': Unit,
                         'StorageResolution': self.storage_resolution,
                     }
             )
 
         md.append({
-                    'MetricName': kwargs.get('MetricName'),
+                    'MetricName': MetricName,
                     'Dimensions': self.dimensions,
                     'Timestamp': ts,
                     'Value': value,
-                    'Unit': unit,
+                    'Unit': Unit,
                     'StorageResolution': self.storage_resolution,
                   })
 
@@ -364,11 +310,10 @@ class FluentMetric(object):
     def _record_metric(self, metric_data):
         logger.debug('log: {}'.format(metric_data))
         self.client.put_metric_data(
-                Namespace=self.namespace,
-                MetricData=metric_data,
+            Namespace=self.namespace,
+            MetricData=metric_data,
         )
 
-    def get_metrics(self, **kwargs):
-        mn = kwargs.get('MetricName')
+    def get_metrics(self, MetricName):
         return self.client.list_metrics(Namespace=self.namespace,
-                                        MetricName=mn)['Metrics']
+                                        MetricName=MetricName)['Metrics']

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -105,10 +105,22 @@ def test_can_push_dimensions():
 @mock.patch('fluentmetrics.FluentMetric.log')
 def test_can_log_count(fm_log):
     m = FluentMetric().with_namespace('Performance')
-    m.count(MetricName='test', Count=2)
+    m.count(MetricName='test', Value=2)
     fm_log.assert_called()
 
 
 def test_can_set_resolution():
     m = FluentMetric().with_namespace('Performance').with_storage_resolution(1)
     assert m.storage_resolution == 1
+
+@mock.patch('fluentmetrics.FluentMetric.log')
+def test_can_count_with_positional_params(fm_log):
+    m = FluentMetric().with_namespace('Performance')
+    m.count('test', 5)
+
+@mock.patch('fluentmetrics.FluentMetric.log')
+def test_can_count_with_no_value(fm_log):
+    m = FluentMetric().with_namespace('Performance')
+    m.count('test')
+
+


### PR DESCRIPTION
## 1. Positional parameters

All methods to take positional parameters. Rather than writing this:

```python
m.count(MetricName='blessings', Value=1)
```

you can shorten it down to

```python
m.count('blessings')
```

## 2. Timers using `with` blocks

```python
with m.timer('PotentiallySlow'):
    run_forest_run()
```

## 3. Timers using decorators

```python
@m.timer('PotentiallySlow')
def run_forest_run()
    across_america()
```

