### PR TITLE
Fix buffer metrics issue on Python 3

### DIFF
--- a/fluentmetrics/buffer.py
+++ b/fluentmetrics/buffer.py
@@ -56,7 +56,7 @@ class BufferedFluentMetric(FluentMetric):
         delaying data.
         '''
         for namespace, buffer in self.buffers.items():
-            full_pages = len(buffer) / PAGE_SIZE
+            full_pages = len(buffer) // PAGE_SIZE
             for i in range(full_pages):
                 start = i * PAGE_SIZE
                 end = (i + 1) * PAGE_SIZE


### PR DESCRIPTION
Currently I am encounter the following issue on python 3:

```
    def flush(self, send_partial = True):
        '''Sends as much data as possible to CloudWatch. If send_partial is set to False,
            this only sends full pages. This way, it minimizes the API usage at the cost of
            delaying data.
            '''
        for namespace, buffer in self.buffers.items():
            full_pages = len(buffer) / PAGE_SIZE
>           for i in range(full_pages):
E           TypeError: 'float' object cannot be interpreted as an integer
```