### PR TITLE
Only fanout dimensions when there are multiple dimensions

### DIFF
--- a/fluentmetrics/metric.py
+++ b/fluentmetrics/metric.py
@@ -338,8 +338,8 @@ class FluentMetric(object):
         value = float(kwargs.get('Value'))
         unit = kwargs.get('Unit')
         md = []
-        for dimension in self.dimensions:
-            if dimension['Name'] != 'MetricStreamId':
+        if len(self.dimensions) > 1:
+            for dimension in self.dimensions:
                 md.append({
                             'MetricName': kwargs.get('MetricName'),
                             'Dimensions': [dimension],

--- a/fluentmetrics/metric.py
+++ b/fluentmetrics/metric.py
@@ -339,15 +339,16 @@ class FluentMetric(object):
         unit = kwargs.get('Unit')
         md = []
         for dimension in self.dimensions:
-            md.append({
-                'MetricName': kwargs.get('MetricName'),
-                'Dimensions': [dimension],
-                'Timestamp': ts,
-                'Value': value,
-                'Unit': unit,
-                'StorageResolution': self.storage_resolution,
-            }
-            )
+            if dimension['Name'] != 'MetricStreamId':
+                md.append({
+                            'MetricName': kwargs.get('MetricName'),
+                            'Dimensions': [dimension],
+                            'Timestamp': ts,
+                            'Value': value,
+                            'Unit': unit,
+                            'StorageResolution': self.storage_resolution,
+                        }
+                )
 
         md.append({
             'MetricName': kwargs.get('MetricName'),


### PR DESCRIPTION
Hi, Currently we encountered an issue where we get duplicated metrics data published when there are no dimensions set (we only have the default `MetricStreamId` set).  It is not quite ideal as it makes
`sample count` and `sum` in graphed metrics not usable because the value always double than expected. 

I think expending the dimensions only make sense when you have more than 1 dimensions. 