### PR TITLE
Prevent MissingRequiredParameterException in _record_metric

### DIFF
--- a/fluentmetrics/metric.py
+++ b/fluentmetrics/metric.py
@@ -363,10 +363,11 @@ class FluentMetric(object):
 
     def _record_metric(self, metric_data):
         logger.debug('log: {}'.format(metric_data))
-        self.client.put_metric_data(
-            Namespace=self.namespace,
-            MetricData=metric_data,
-        )
+        if metric_data:
+            self.client.put_metric_data(
+                Namespace=self.namespace,
+                MetricData=metric_data,
+            )
 
     def get_metrics(self, **kwargs):
         mn = kwargs.get('MetricName')


### PR DESCRIPTION
#13 occurs due to an empty metric_data list. Adding a simple condition for metric_data to have content.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
