### PR TITLE
major bug fix in BufferedFluentMetric.flush

### DIFF
--- a/fluentmetrics/buffer.py
+++ b/fluentmetrics/buffer.py
@@ -62,7 +62,7 @@ class BufferedFluentMetric(FluentMetric):
                 FluentMetric._record_metric(self, page)
 
             start = full_pages * PAGE_SIZE
-            end = len(buffer) % PAGE_SIZE
+            end = start + (len(buffer) % PAGE_SIZE)
             if send_partial:
                 # ship remaining items
                 page = buffer[start:end]


### PR DESCRIPTION
this wasted 2 days of my time assuming cloudwatch is dropping metrics when it was this bug here. it seems you haven't even tested your code with more than 20 metrics.

*Issue #, if available:*
when there are more than `PAGE_SIZE` metrics in the buffer, and `BufferedFluentMetric.flush` is called with `send_partial=True`, it will not send the remaining metrics because of a bug in the way "end" is calculated. It would only work if you have less than 20 metrics in the buffer. If there are 23 (or 63) for example, it would never send the remaining 3.

*Description of changes:*
`end` should be `start` + `(len(buffer) % PAGE_SIZE)` and not just `(len(buffer) % PAGE_SIZE)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
